### PR TITLE
feat: add an url return

### DIFF
--- a/discord-phub.browser.js
+++ b/discord-phub.browser.js
@@ -9,6 +9,7 @@ class NSFWElement{
         this.url = url;
         this.category = category;
         this.type = findLinkType(url);
+        return { url: this.url }
     }
 }
 

--- a/discord-phub.js
+++ b/discord-phub.js
@@ -19,6 +19,7 @@ class NSFWElement{
         this.url = url;
         this.category = category;
         this.type = findLinkType(url);
+        return { url : this.url }
     }
 }
 

--- a/test/test-url.js
+++ b/test/test-url.js
@@ -1,0 +1,20 @@
+const { RandomPHUB } = require('../discord-phub');
+
+//If you want to generate unique media each time else set it to false (by default it's false)
+const nsfw = new RandomPHUB(unique = true);
+
+const pussy = nsfw.getRandomInCategory('pussy', "gif").url; //will return a link to a pussy gif
+const pussy2 = nsfw.getRandomInCategory('pussy').url; //will return a link to a pussy media 
+const rnd = nsfw.getRandom("gif").url; //will return a link to a random media of any categorie with gif type
+const rnd2 = nsfw.getRandom().url; //will return a link to a random media of any categorie with any type
+const cat = nsfw.getRandomCategory(); //will return a random category
+const type = nsfw.getRandomType(); //will return a random category
+
+console.log(pussy);
+console.log(pussy2);
+
+console.log(rnd);
+console.log(rnd2);
+
+console.log(cat); // returns only a string
+console.log(type); // returns only a string


### PR DESCRIPTION
Added in both, Browser and Node

Usage
```js
const { RandomPHUB } = require('../discord-phub');

//If you want to generate unique media each time else set it to false (by default it's false)
const nsfw = new RandomPHUB(unique = true);

const pussy = nsfw.getRandomInCategory('pussy', "gif").url; //will return a link to a pussy gif
const pussy2 = nsfw.getRandomInCategory('pussy').url; //will return a link to a pussy media 
const rnd = nsfw.getRandom("gif").url; //will return a link to a random media of any categorie with gif type
const rnd2 = nsfw.getRandom().url; //will return a link to a random media of any categorie with any type
const cat = nsfw.getRandomCategory(); //will return a random category
const type = nsfw.getRandomType(); //will return a random category

console.log(pussy);
console.log(pussy2);

console.log(rnd);
console.log(rnd2);

console.log(cat); // returns only a string
console.log(type); // returns only a string
```

Logs
```log
PS C:\Users\**********\Documents\GitHub\unpublished\discord-phub> node test/test-url.js
https://cdn.discordapp.com/attachments/827918526685642782/900870938478911518/PXL_20211021_195627902._exported_stabilized_1634854153977.gif
https://cdn.discordapp.com/attachments/827918526685642782/910947914430423050/redgifs_crookedunluckyboa.mp4
https://cdn.discordapp.com/attachments/599633085948100628/887929713388048394/PXL_20210913_221707250._exported_stabilized_1631767448209.gif
https://cdn.discordapp.com/attachments/542910700033409024/853489642741694484/photo_2021-06-12_18.22.55.jpeg
hentai
gif
```